### PR TITLE
Allowed null filtering for JSONType fields

### DIFF
--- a/src/codeGen/createTypeSchema.js
+++ b/src/codeGen/createTypeSchema.js
@@ -301,6 +301,10 @@ function queriesForField(fieldName, realFieldType) {
       result.push(`${fieldName}: ${fieldType}`);
       result.push(`${fieldName}_ne: ${fieldType}`);
       result.push(`${fieldName}_in: [${fieldType}]`);
+      break;
+    case JSONType:
+      result.push(`${fieldName}: ${fieldType}`);
+      result.push(`${fieldName}_ne: ${fieldType}`);
   }
 
   if (realFieldType.__isObject || realFieldType.__isArray) {

--- a/test/testProject1/jsonType.test.js
+++ b/test/testProject1/jsonType.test.js
@@ -24,6 +24,46 @@ test("Creation mutation works with JSON", async () => {
   expect(obj).toEqual({ title: "Book 1", jsonContent: { a: 1, b: "b" } });
 });
 
+test("Query null", async () => {
+  const withJson = await runMutation({
+    mutation: `createBook(Book: {title: "Book 1", jsonContent: {a: 1, b: "b"}}){Book{_id, title, jsonContent}}`,
+    result: "createBook"
+  });
+  expect(withJson.jsonContent).toBeDefined();
+  const withoutJson = await runMutation({
+    mutation: `createBook(Book: {title: "Book 1"}){Book{_id, title, jsonContent}}`,
+    result: "createBook"
+  });
+  expect(withoutJson.jsonContent).toBe(null);
+  
+
+  await queryAndMatchArray({
+    query: `{allBooks(jsonContent: null){Books{_id}}}`,
+    coll: "allBooks",
+    results: [{ _id: withoutJson._id }]
+  });
+});
+
+test("Query not null", async () => {
+  const withJson = await runMutation({
+    mutation: `createBook(Book: {title: "Book 1", jsonContent: {a: 1, b: "b"}}){Book{_id, title, jsonContent}}`,
+    result: "createBook"
+  });
+  expect(withJson.jsonContent).toBeDefined();
+  const withoutJson = await runMutation({
+    mutation: `createBook(Book: {title: "Book 1"}){Book{_id, title, jsonContent}}`,
+    result: "createBook"
+  });
+  expect(withoutJson.jsonContent).toBe(null);
+  
+
+  await queryAndMatchArray({
+    query: `{allBooks(jsonContent_ne: null){Books{_id}}}`,
+    coll: "allBooks",
+    results: [{ _id: withJson._id }]
+  });
+});
+
 test("Update JSON", async () => {
   let obj = await runMutation({
     mutation: `createBook(Book: {title: "Book 1", jsonContent: {a: 1, b: "b"}}){Book{_id, title, jsonContent}}`,


### PR DESCRIPTION
Solves last issue described here: https://github.com/arackaf/mongo-graphql-starter/issues/21#issuecomment-400631553

Fixes #21.