### PR TITLE
prevent TypeError: "module[k].fields is undefined"

### DIFF
--- a/src/createGraphqlSchema.js
+++ b/src/createGraphqlSchema.js
@@ -28,6 +28,7 @@ export default function(source, destPath) {
     }
     Object.keys(module).forEach(k => {
       module[k].__name = k;
+      if (!module[k].fields) module[k].fields = {};
       if (!module[k].fields._id && module[k].table) {
         //add _id, and as a bonus, make it show up first in the list since the spec iterates object keys in order of insertion
         module[k].fields = { _id: MongoIdType, ...module[k].fields };


### PR DESCRIPTION
I am working on a typescript project, so I also generate the schema locally with `ts-node` command instead of `@std/esm`. (like so: `ts-node ./src/generateSchema/generate.ts`).
This works, but tslint stops on a TypeError: `module[k].fields is undefined`.
This small fix prevents it.
