### PR TITLE
Add readonly option to relationships

### DIFF
--- a/README.md
+++ b/README.md
@@ -791,6 +791,7 @@ For `one-to-many` relationships, after creating new objects using the `create<Ty
 | `keyField`            | `_id`     | The field that will be used to look up related objects in their collection. |
 | `oneToOne`            | (none)    | Specify `true` to force the relationship to create a single object, even if the `keyField` is not `_id`. |
 | `oneToMany`           | (none)    | Specify `true` to force the relationship to create an array, regardless of `fkField` and `keyField`.  |
+| `readonly`            | (none)    | Specify `true` to set the relationship only in output type.  |
 
 ### Using relationships
 

--- a/src/codeGen/createTypeSchema.js
+++ b/src/codeGen/createTypeSchema.js
@@ -72,7 +72,10 @@ ${[
       : null,
     createInput(`${name}Input`, [
       ...Object.keys(fields).map(k => `${k}: ${fieldType(fields[k], true)}`),
-      ...Object.keys(relationships).map(k => `${k}: ${relationshipType(relationships[k], true)}`)
+      ...Object.keys(relationships).map(k => {
+        if (relationships[k].readonly) return '';
+        else return `${k}: ${relationshipType(relationships[k], true)}`
+      })
     ]),
     createInput(`${name}MutationInput`, [
       ...flatMap(Object.keys(fields).filter(k => k != "_id"), k => fieldMutations(k, fields)),


### PR DESCRIPTION
PR to issue https://github.com/arackaf/mongo-graphql-starter/issues/34

Add readonly property to relationship configuration. If set to 'true', the relation can only be user in output.