### PR TITLE
Added Fragment Support

### DIFF
--- a/src/projectUtilities.js
+++ b/src/projectUtilities.js
@@ -99,8 +99,19 @@ export function getAllNestedQueryInfoAsts(ast, queryName) {
   return fieldNode.selectionSet.selections.find(fn => fn.kind == "Field" && fn.name && fn.name.value == queryName);
 }
 
-function getSelections(fieldNode) {
-  return new Map(fieldNode.selectionSet.selections.map(sel => [sel.name.value, sel.selectionSet == null ? true : getSelections(sel)]));
+function getSelections(fieldNode, fragments) {
+  return new Map(
+    fieldNode.selectionSet.selections.reduce((acc, sel) => {
+      if (sel.kind === "FragmentSpread") {
+        return [...acc, ...getSelections(fragments[sel.name.value], fragments)];
+      }
+      const y = [
+        sel.name.value,
+        sel.selectionSet == null ? true : getSelections(sel)
+      ];
+      return [...acc, y];
+    }, [])
+  );
 }
 
 //leave a simple forward call for now, in case sub-field GraphQL aliasing becomes a thing, per https://github.com/graphql/graphql-js/issues/297

--- a/test/testProject1/queryFragmentSupport.test.js
+++ b/test/testProject1/queryFragmentSupport.test.js
@@ -1,0 +1,99 @@
+import spinUp from "./spinUp";
+import { ObjectId } from "mongodb";
+
+let db, schema, queryAndMatchArray, runMutation, close;
+beforeAll(async () => {
+  ({ db, schema, queryAndMatchArray, runMutation, close } = await spinUp());
+
+  await db.collection("books").insertOne({
+    _id: ObjectId("59e3dbdf94dc6983d41deece"),
+    title: "Book 1",
+    weight: 5.1,
+    pages: 600,
+    isRead: true,
+    createdOn: new Date("2004-06-02T01:30:45"),
+    createdOnYearOnly: new Date("2004-06-02T01:30:45")
+  });
+});
+
+afterAll(async () => {
+  await db.collection("books").deleteMany({});
+  close();
+  db = null;
+});
+
+test("Query without fragment: to give a baseline.", async () => {
+  await queryAndMatchArray({
+    query: `{getBook(_id: "59e3dbdf94dc6983d41deece"){Book{title weight}}}`,
+    coll: "getBook",
+    results: { title: "Book 1", weight: 5.1 }
+  });
+});
+
+test("Query with fragment: Happy Path - One level of Fragments.", async () => {
+  await queryAndMatchArray({
+    query: `fragment d1 on Book {title} query{getBook(_id: "59e3dbdf94dc6983d41deece"){Book{...d1 weight}}}`,
+    coll: "getBook",
+    results: { title: "Book 1", weight: 5.1 }
+  });
+});
+
+test("Query with 2 level deep fragments.", async () => {
+  await queryAndMatchArray({
+    query: `
+    fragment d1 on Book {
+      title
+    }
+    fragment d2 on Book {
+      ...d1
+      pages
+    }
+    query {
+      getBook(_id: "59e3dbdf94dc6983d41deece") {
+        Book {
+          ...d2
+          weight
+        }
+      }
+    }`,
+    coll: "getBook",
+    results: {
+      title: "Book 1",
+      pages: 600,
+      weight: 5.1
+    }
+  });
+});
+
+test("Query with 3 level deep fragments.", async () => {
+  await queryAndMatchArray({
+    query: `
+    fragment d1 on Book {
+      title
+    }
+    fragment d2 on Book {
+      ...d1
+      pages
+    }
+
+    fragment d3 on Book {
+      ...d2
+      isRead
+    }
+    query {
+      getBook(_id: "59e3dbdf94dc6983d41deece") {
+        Book {
+          ...d3
+          weight
+        }
+      }
+    }`,
+    coll: "getBook",
+    results: {
+      title: "Book 1",
+      pages: 600,
+      isRead: true,
+      weight: 5.1
+    }
+  });
+});


### PR DESCRIPTION
Create new tests to verify that the requested fields are included in the $project

This was done by modifying the `getSelections()` function to use a reduce function over map.
This allowed to check if `sel.kind === 'FragmentSpread'`; if so, perform another recursive call to `getSelections`
A second argument was added to `getSelections`, which is the fragments of the incoming query.

The tests go 3 levels deep of fragments.

Closes #55 

**Please note**
I ran the full suite of test on the branch I used to developed the new feature; there were 6 failed suites with regards to `close()` not being a function, on unrelated test projects.
I switched to the master branch and made sure to do a pull from upstream (your project). However there were still 6 test suites that are failing. Leading me to believe my changes did not cause the failures. :crossed_fingers: :crossed_fingers: 

I was not able to figure out why those tests are failing since `spinup()` in those directories is exporting a `close()` fn..... Could you help me out with them?

Hope the new fragment support works out!

![mongo-starter-graphql-failing-test-report-01-03-2019](https://user-images.githubusercontent.com/10660283/71750388-36312400-2e46-11ea-8685-8e495d324bfa.png)
